### PR TITLE
feat(document): notes edit/delete actions, add FAB; star/unstar toggl…

### DIFF
--- a/app/src/main/java/io/github/stcksmsh/pravnik/ui/document/DocumentFragment.kt
+++ b/app/src/main/java/io/github/stcksmsh/pravnik/ui/document/DocumentFragment.kt
@@ -20,6 +20,8 @@ import io.github.stcksmsh.pravnik.domain.repo.DefinitionsRepo
 import io.github.stcksmsh.pravnik.domain.repo.TariffsRepo
 import io.github.stcksmsh.pravnik.domain.repo.UnitsRepo
 import io.github.stcksmsh.pravnik.domain.repo.DocumentsRepo
+import io.github.stcksmsh.pravnik.domain.repo.HistoryRepo
+import io.github.stcksmsh.pravnik.domain.model.History
 import io.github.stcksmsh.pravnik.ui.document.tabs.ReadTabFragment
 import io.github.stcksmsh.pravnik.ui.document.tabs.SimpleListTabFragment
 import io.github.stcksmsh.pravnik.ui.util.RenderUtils
@@ -37,6 +39,7 @@ class DocumentFragment : Fragment() {
     @Inject lateinit var definitionsRepo: DefinitionsRepo
     @Inject lateinit var tariffsRepo: TariffsRepo
     @Inject lateinit var documentsRepo: DocumentsRepo
+    @Inject lateinit var historyRepo: HistoryRepo
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
         _binding = FragmentDocumentBinding.inflate(inflater, container, false)
@@ -44,12 +47,18 @@ class DocumentFragment : Fragment() {
     }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        binding.starBtn.setOnClickListener { toggleStar() }
+
         super.onViewCreated(view, savedInstanceState)
         setupTabs()
         // Update title from document
         viewLifecycleOwner.lifecycleScope.launch {
             val doc = documentsRepo.get(args.docId)
             binding.title.text = doc?.title ?: args.docId
+        }
+        // Insert into history
+        viewLifecycleOwner.lifecycleScope.launch {
+            historyRepo.insert(History(id = 0, docId = args.docId, unitAnchor = args.anchor ?: "", visitedAt = System.currentTimeMillis()))
         }
         parentFragmentManager.setFragmentResultListener("doc_anchor", viewLifecycleOwner) { _, bundle ->
             val anchor = bundle.getString("anchor").orEmpty()
@@ -97,6 +106,15 @@ class DocumentFragment : Fragment() {
         val list = v.findViewById<android.widget.ListView>(R.id.outlineList)
         viewLifecycleOwner.lifecycleScope.launch {
             val labels = unitsRepo.listLabels(args.docId)
+    private fun toggleStar() {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val docId = args.docId
+            val starred = documentsRepo.listStarred().any { it.id == docId }
+            if (starred) documentsRepo.unstar(docId) else documentsRepo.star(docId)
+            Toast.makeText(requireContext(), if (starred) R.string.unstarred else R.string.starred, Toast.LENGTH_SHORT).show()
+        }
+    }
+
             list.adapter = android.widget.ArrayAdapter(ctx, android.R.layout.simple_list_item_1, labels.map { it.label })
             list.setOnItemClickListener { _, _, position, _ ->
                 val anchor = labels[position].anchor

--- a/app/src/main/java/io/github/stcksmsh/pravnik/ui/document/tabs/SimpleListTabFragment.kt
+++ b/app/src/main/java/io/github/stcksmsh/pravnik/ui/document/tabs/SimpleListTabFragment.kt
@@ -31,23 +31,37 @@ class SimpleListTabFragment : Fragment() {
         return inflater.inflate(R.layout.fragment_simple_list_tab, container, false)
     }
 
+    private var notes: List<io.github.stcksmsh.pravnik.domain.model.Note> = emptyList()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         val docId = requireArguments().getString("docId")!!
         val mode = requireArguments().getString("mode") // defs | tariffs | notes | meta | citations
         val listView: android.widget.ListView = view.findViewById(R.id.list)
         val addFab: com.google.android.material.floatingactionbutton.FloatingActionButton = view.findViewById(R.id.addFab)
-        if (mode == "notes") addFab.visibility = View.VISIBLE else addFab.visibility = View.GONE
+        addFab.visibility = if (mode == "notes") View.VISIBLE else View.GONE
         addFab.setOnClickListener { promptAddNote(docId) }
+        if (mode == "notes") {
+            listView.setOnItemClickListener { _, _, position, _ ->
+                val note = notes.getOrNull(position) ?: return@setOnItemClickListener
+                showNoteActions(docId, note)
+            }
+        }
         viewLifecycleOwner.lifecycleScope.launch {
-            val items: List<String> = when (mode) {
-                "defs" -> definitionsRepo.listForDoc(docId).map { it.term + ": " + it.text }
-                "tariffs" -> tariffsRepo.listForDoc(docId).map { (it.title ?: it.key) + (it.amount?.let { a -> " — $a" } ?: "") }
-                "notes" -> notesRepo.listForDoc(docId).map { it.body }
+            when (mode) {
+                "defs" -> {
+                    val items = definitionsRepo.listForDoc(docId).map { it.term + ": " + it.text }
+                    listView.adapter = ArrayAdapter(requireContext(), android.R.layout.simple_list_item_1, items)
+                }
+                "tariffs" -> {
+                    val items = tariffsRepo.listForDoc(docId).map { (it.title ?: it.key) + (it.amount?.let { a -> " — $a" } ?: "") }
+                    listView.adapter = ArrayAdapter(requireContext(), android.R.layout.simple_list_item_1, items)
+                }
+                "notes" -> loadNotes(docId, listView)
                 "meta" -> {
                     val case = caseMetaRepo.get(docId)
                     val practice = practiceMetaRepo.get(docId)
-                    when {
+                    val items = when {
                         case != null -> listOfNotNull(
                             "Court: ${'$'}{case.court}",
                             "Case no: ${'$'}{case.caseNumber}",
@@ -61,17 +75,23 @@ class SimpleListTabFragment : Fragment() {
                         )
                         else -> emptyList()
                     }
+                    listView.adapter = ArrayAdapter(requireContext(), android.R.layout.simple_list_item_1, items)
                 }
                 "citations" -> {
-                    val from = citatorRepo.listFrom(docId).map { "Cites → ${'$'}{it.toId}" }
-                    val to = citatorRepo.listTo(docId).map { "Cited by ← ${'$'}{it.fromId}" }
-                    from + to
+                    val from = citatorRepo.listFrom(docId).map { "Cites → ${'$'}{it.toDocId}" }
+                    val to = citatorRepo.listTo(docId).map { "Cited by ← ${'$'}{it.fromDocId}" }
+                    val items = from + to
+                    listView.adapter = ArrayAdapter(requireContext(), android.R.layout.simple_list_item_1, items)
                 }
-                else -> emptyList()
+                else -> listView.adapter = ArrayAdapter(requireContext(), android.R.layout.simple_list_item_1, emptyList<String>())
             }
-            listView.adapter = ArrayAdapter(requireContext(), android.R.layout.simple_list_item_1, items)
 
         }
+    }
+    
+    private suspend fun loadNotes(docId: String, listView: android.widget.ListView) {
+        notes = notesRepo.listForDoc(docId)
+        listView.adapter = ArrayAdapter(requireContext(), android.R.layout.simple_list_item_1, notes.map { it.body })
     }
 
     private fun promptAddNote(docId: String) {
@@ -87,15 +107,56 @@ class SimpleListTabFragment : Fragment() {
                         notesRepo.upsert(io.github.stcksmsh.pravnik.domain.model.Note(
                             id = 0,
                             docId = docId,
-                            unitAnchor = "", // TODO: wire current anchor if available
+                            unitAnchor = "",
                             title = null,
                             body = body,
                             updatedAt = System.currentTimeMillis()
                         ))
-                        // refresh
                         view?.findViewById<android.widget.ListView>(R.id.list)?.let { list ->
-                            val items = notesRepo.listForDoc(docId).map { it.body }
-                            list.adapter = android.widget.ArrayAdapter(ctx, android.R.layout.simple_list_item_1, items)
+                            loadNotes(docId, list)
+                        }
+                    }
+                }
+                d.dismiss()
+            }
+            .setNegativeButton(android.R.string.cancel, null)
+            .show()
+    }
+
+    private fun showNoteActions(docId: String, note: io.github.stcksmsh.pravnik.domain.model.Note) {
+        val ctx = requireContext()
+        val options = arrayOf(getString(R.string.edit), getString(R.string.delete))
+        com.google.android.material.dialog.MaterialAlertDialogBuilder(ctx)
+            .setItems(options) { d, which ->
+                when (which) {
+                    0 -> promptEditNote(docId, note)
+                    1 -> {
+                        viewLifecycleOwner.lifecycleScope.launch {
+                            notesRepo.delete(note.id)
+                            view?.findViewById<android.widget.ListView>(R.id.list)?.let { list ->
+                                loadNotes(docId, list)
+                            }
+                        }
+                    }
+                }
+                d.dismiss()
+            }
+            .show()
+    }
+
+    private fun promptEditNote(docId: String, note: io.github.stcksmsh.pravnik.domain.model.Note) {
+        val ctx = requireContext()
+        val input = android.widget.EditText(ctx).apply { setText(note.body) }
+        com.google.android.material.dialog.MaterialAlertDialogBuilder(ctx)
+            .setTitle(R.string.edit)
+            .setView(input)
+            .setPositiveButton(R.string.save) { d, _ ->
+                val body = input.text?.toString()?.trim().orEmpty()
+                if (body.isNotEmpty()) {
+                    viewLifecycleOwner.lifecycleScope.launch {
+                        notesRepo.upsert(note.copy(body = body, updatedAt = System.currentTimeMillis()))
+                        view?.findViewById<android.widget.ListView>(R.id.list)?.let { list ->
+                            loadNotes(docId, list)
                         }
                     }
                 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -20,6 +20,9 @@
     <string name="star">Star</string>
     <string name="star_doc">Star this document</string>
 
+    <string name="starred">Starred</string>
+    <string name="unstarred">Unstarred</string>
+
     <string name="add_note">Add note</string>
     <string name="edit">Edit</string>
     <string name="delete">Delete</string>


### PR DESCRIPTION
…e on Document; insert History on open.\n\n- Notes tab now supports add/edit/delete via Material dialogs\n- Star button toggles star state and shows toast\n- On open, a History entry is recorded\n\nCo-authored-by: openhands <openhands@all-hands.dev>